### PR TITLE
Add thinking controls to Nano Banana 2 nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ config.json
 # OS
 .DS_Store
 Thumbs.db
+
+# Dev
+.ignore/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Thumbs.db
 
 # Dev
 .ignore/
+.agents/
+.codex/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the ComfyUI_Nano_Banana project will be documented in thi
   - Added `thinking_level` (`minimal` or `high`) and `include_thoughts` controls to Nano Banana 2 AIO and Nano Banana 2 Multi-Turn Chat nodes.
   - Added `thought_images` outputs for returned intermediate thought images.
   - Updated Nano Banana 2 default model to `gemini-3.1-flash-image` while keeping the preview identifier selectable.
+- Nano Banana 2 seed control
+  - Added a `seed` widget to Nano Banana 2 AIO and Nano Banana 2 Multi-Turn Chat nodes.
+  - Enabled ComfyUI fixed, increment, decrement, and randomize seed behavior through `control_after_generate`.
+  - Sends the selected seed in the Gemini generation config for both API and Vertex AI client paths.
 
 ### Changed
 - Nano Banana 2 response parsing now separates thought text/images from final response text/images, preventing thought images from being mistaken for final output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the ComfyUI_Nano_Banana project will be documented in this file.
 
+## Unreleased
+### Added
+- Nano Banana 2 thinking controls
+  - Added `thinking_level` (`minimal` or `high`) and `include_thoughts` controls to Nano Banana 2 AIO and Nano Banana 2 Multi-Turn Chat nodes.
+  - Added `thought_images` outputs for returned intermediate thought images.
+  - Updated Nano Banana 2 default model to `gemini-3.1-flash-image` while keeping the preview identifier selectable.
+
+### Changed
+- Nano Banana 2 response parsing now separates thought text/images from final response text/images, preventing thought images from being mistaken for final output.
+- Nano Banana 2 AIO no longer replaces API text/grounding output with Vertex AI guidance text.
+
 ## [6.1.0] - Nano Banana 2 Support 2026-03-02
 ### Added
 - Nano Banana 2 AIO Node

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A dedicated node for the gemini-3.1-flash-image model with support for:
 - 512px (0.5K) resolution option
 - Google Image Search grounding alongside Web Search
 - Thinking level controls and optional returned thought text/images
+- Seed control with fixed, increment, decrement, and randomize modes
 
 **New Nano Banana 2 Multi-Turn Chat Node:**
 A conversational image generation and editing node with all Nano Banana 2 features:
@@ -213,6 +214,7 @@ A dedicated node for the **gemini-3.1-flash-image** model, optimized for speed a
 *   `use_image_search` (BOOLEAN): Toggle to enable Google Image Search grounding for visual reference accuracy (default: `False`). Enable `use_search` to use this feature.
 *   `thinking_level` (STRING): Thinking budget for Nano Banana 2. Options: `minimal`, `high` (default: `minimal`).
 *   `include_thoughts` (BOOLEAN): Whether returned thought text and thought images should be exposed in the node outputs (default: `False`).
+*   `seed` (INT): Generation seed sent to the Gemini generation config. Use ComfyUI's seed control to keep it fixed, increment, decrement, or randomize it after each generation. Seeds are best-effort reproducibility controls, not guaranteed deterministic outputs.
 *   `image_1` to `image_14` (IMAGE, optional): Up to fourteen reference images. Gemini 3.1 Flash supports up to 10 object images with high-fidelity and up to 4 character images for consistency.
 *   `aspect_ratio` (STRING): The output aspect ratio for the generated image. Options include: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9`, `Auto` (default: `1:1`). When set to `Auto`, the AI automatically determines the optimal aspect ratio.
 *   `image_size` (STRING): The output image quality/size. Options include: `512px`, `1K`, `2K`, `4K` (default: `2K`). The `512px` option is exclusive to Nano Banana 2.
@@ -258,6 +260,7 @@ A conversational image generation and editing node using the **gemini-3.1-flash-
 *   `use_image_search` (BOOLEAN): Toggle to enable Google Image Search grounding for visual reference accuracy (default: `False`). Enable `use_search` to use this feature.
 *   `thinking_level` (STRING): Thinking budget for Nano Banana 2. Options: `minimal`, `high` (default: `minimal`).
 *   `include_thoughts` (BOOLEAN): Whether returned thought text and thought images should be exposed in the node outputs (default: `False`).
+*   `seed` (INT): Generation seed sent to the Gemini generation config. Use ComfyUI's seed control to keep it fixed, increment, decrement, or randomize it after each generation. Seeds are best-effort reproducibility controls, not guaranteed deterministic outputs.
 *   `aspect_ratio` (STRING): The output aspect ratio for the generated image. Options include: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9`, `Auto` (default: `1:1`). When set to `Auto`, the AI automatically determines the optimal aspect ratio.
 *   `image_size` (STRING): The output image quality/size. Options include: `512px`, `1K`, `2K`, `4K` (default: `2K`). The `512px` option is exclusive to Nano Banana 2.
 *   `temperature` (FLOAT): Controls the creative randomness of the output. Higher values (e.g., 1.2) are more creative, lower values (e.g., 0.5) are more deterministic (default: 1.0).

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ A set of custom nodes for ComfyUI that leverage both Google Vertex AI and Google
 ## What's New
 
 ### Version 6.1.0 - Nano Banana 2 Support
-This minor update adds support for the new Nano Banana 2 model (gemini-3.1-flash-image-preview), optimized for speed and high-volume use cases.
+This minor update adds support for the new Nano Banana 2 model (gemini-3.1-flash-image), optimized for speed and high-volume use cases.
 
 #### New Features:
 
 **New Nano Banana 2 AIO Node:**
-A dedicated node for the gemini-3.1-flash-image-preview model with support for:
+A dedicated node for the gemini-3.1-flash-image model with support for:
 - Up to 14 reference images (10 objects + 4 characters)
 - New aspect ratios: 1:4, 4:1, 1:8, 8:1
 - 512px (0.5K) resolution option
 - Google Image Search grounding alongside Web Search
+- Thinking level controls and optional returned thought text/images
 
 **New Nano Banana 2 Multi-Turn Chat Node:**
 A conversational image generation and editing node with all Nano Banana 2 features:
@@ -199,17 +200,19 @@ This node supports conversational image generation and editing with preserved co
 
 ### Nano Banana 2 AIO
 
-A dedicated node for the **gemini-3.1-flash-image-preview** model, optimized for speed and high-volume use cases. This node provides all the latest features including support for up to 14 reference images, new extreme aspect ratios, and Google Image Search grounding.
+A dedicated node for the **gemini-3.1-flash-image** model, optimized for speed and high-volume use cases. This node provides all the latest features including support for up to 14 reference images, new extreme aspect ratios, Google Image Search grounding, and configurable thinking.
 
 **Note:** Requires the latest `google-genai` package. Update with: `pip install google-genai --upgrade`
 
 **Inputs:**
 
-*   `model_name` (STRING): The Gemini model to use. Currently using: `gemini-3.1-flash-image-preview` for high-efficiency image generation (default: `gemini-3.1-flash-image-preview`).
+*   `model_name` (STRING): The Gemini model to use. Currently using: `gemini-3.1-flash-image` for high-efficiency image generation (default: `gemini-3.1-flash-image`; preview model remains selectable).
 *   `prompt` (STRING): The text prompt for image generation or manipulation.
 *   `image_count` (INT): Number of images to generate (1-10). When set to 1, behaves like single image generation; when >1, generates multiple sequential images (default: 1).
 *   `use_search` (BOOLEAN): Toggle to enable or disable Google Search functionality (default: `False`).
 *   `use_image_search` (BOOLEAN): Toggle to enable Google Image Search grounding for visual reference accuracy (default: `False`). Enable `use_search` to use this feature.
+*   `thinking_level` (STRING): Thinking budget for Nano Banana 2. Options: `minimal`, `high` (default: `minimal`).
+*   `include_thoughts` (BOOLEAN): Whether returned thought text and thought images should be exposed in the node outputs (default: `False`).
 *   `image_1` to `image_14` (IMAGE, optional): Up to fourteen reference images. Gemini 3.1 Flash supports up to 10 object images with high-fidelity and up to 4 character images for consistency.
 *   `aspect_ratio` (STRING): The output aspect ratio for the generated image. Options include: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9`, `Auto` (default: `1:1`). When set to `Auto`, the AI automatically determines the optimal aspect ratio.
 *   `image_size` (STRING): The output image quality/size. Options include: `512px`, `1K`, `2K`, `4K` (default: `2K`). The `512px` option is exclusive to Nano Banana 2.
@@ -236,24 +239,25 @@ A dedicated node for the **gemini-3.1-flash-image-preview** model, optimized for
 **Outputs:**
 
 *   `images` (IMAGE): Batch of generated images (single image when image_count=1, multiple images when image_count>1).
-*   `thinking` (STRING): The AI's thought process and reasoning (only available when using Vertex AI approach; shows helpful message for API users).
+*   `thinking` (STRING): Returned thought text when `include_thoughts` is enabled.
 *   `grounding_sources` (STRING): Citation information with source URLs and search queries used to generate the response. Includes both web and image search results when enabled.
-
-**Note:** When using the Google Generative AI API approach (as opposed to VertexAI), the thinking and grounding_sources outputs will include helpful messages about using Vertex AI for full capabilities.
+*   `thought_images` (IMAGE): Returned intermediate thought images when `include_thoughts` is enabled, or a blank placeholder image when none are returned.
 
 ### Nano Banana 2 Multi-Turn Chat
 
-A conversational image generation and editing node using the **gemini-3.1-flash-image-preview** model. Supports multi-turn conversations with preserved context, allowing iterative image modifications. Includes all Nano Banana 2 features: 14 reference images, extreme aspect ratios, and Image Search grounding.
+A conversational image generation and editing node using the **gemini-3.1-flash-image** model. Supports multi-turn conversations with preserved context, allowing iterative image modifications. Includes all Nano Banana 2 features: 14 reference images, extreme aspect ratios, Image Search grounding, and configurable thinking.
 
 **Note:** Requires the latest `google-genai` package. Update with: `pip install google-genai --upgrade`
 
 **Inputs:**
 
-*   `model_name` (STRING): The Gemini model to use. Currently using: `gemini-3.1-flash-image-preview` for high-efficiency image generation (default: `gemini-3.1-flash-image-preview`).
+*   `model_name` (STRING): The Gemini model to use. Currently using: `gemini-3.1-flash-image` for high-efficiency image generation (default: `gemini-3.1-flash-image`; preview model remains selectable).
 *   `prompt` (STRING): The text prompt for image generation or modification based on previous conversation context.
 *   `reset_chat` (BOOLEAN): Toggle to reset the conversation history and start a fresh chat session (default: `False`).
 *   `use_search` (BOOLEAN): Toggle to enable or disable Google Search functionality (default: `False`).
 *   `use_image_search` (BOOLEAN): Toggle to enable Google Image Search grounding for visual reference accuracy (default: `False`). Enable `use_search` to use this feature.
+*   `thinking_level` (STRING): Thinking budget for Nano Banana 2. Options: `minimal`, `high` (default: `minimal`).
+*   `include_thoughts` (BOOLEAN): Whether returned thought text and thought images should be exposed in the node outputs (default: `False`).
 *   `aspect_ratio` (STRING): The output aspect ratio for the generated image. Options include: `1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, `21:9`, `Auto` (default: `1:1`). When set to `Auto`, the AI automatically determines the optimal aspect ratio.
 *   `image_size` (STRING): The output image quality/size. Options include: `512px`, `1K`, `2K`, `4K` (default: `2K`). The `512px` option is exclusive to Nano Banana 2.
 *   `temperature` (FLOAT): Controls the creative randomness of the output. Higher values (e.g., 1.2) are more creative, lower values (e.g., 0.5) are more deterministic (default: 1.0).
@@ -283,13 +287,13 @@ A conversational image generation and editing node using the **gemini-3.1-flash-
 *   `response_text` (STRING): The AI's response text to the current prompt.
 *   `metadata` (STRING): Generation metadata including finish reason and safety ratings.
 *   `chat_history` (STRING): Complete conversation history with all prompts and responses.
+*   `thinking` (STRING): Returned thought text when `include_thoughts` is enabled.
+*   `thought_images` (IMAGE): Returned intermediate thought images when `include_thoughts` is enabled, or a blank placeholder image when none are returned.
 
 **Example Workflow:**
 - First execution: Connect reference images and enter "Create a product shot of this perfume bottle on a marble pedestal"
 - Second execution: "Change the background to a sunset beach scene"
 - Third execution: "Add water droplets on the bottle for a fresh look"
-
-**Note:** When using the Google Generative AI API approach (as opposed to VertexAI), outputs will include helpful messages about using Vertex AI for full capabilities.
 
 ## Example Usage
 

--- a/nodes/nano_banana_2_aio.py
+++ b/nodes/nano_banana_2_aio.py
@@ -32,6 +32,7 @@ class NanoBanana2AIO:
                 "use_image_search": ("BOOLEAN", {"default": False}),
                 "thinking_level": (["minimal", "high"], {"default": "minimal"}),
                 "include_thoughts": ("BOOLEAN", {"default": False}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "control_after_generate": True}),
             },
             "optional": {
                 "image_1": ("IMAGE",), "image_2": ("IMAGE",), "image_3": ("IMAGE",),
@@ -51,7 +52,7 @@ class NanoBanana2AIO:
     FUNCTION = "generate_unified"
     CATEGORY = "Ru4ls/NanoBanana"
 
-    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts):
+    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts, seed):
         """Centralized config creation with proper AFC handling and Image Search support."""
         if "preview" in model_name and not self._preview_warning_shown:
             print(f"Warning: Using preview model {model_name} which may have unstable tool support")
@@ -68,6 +69,7 @@ class NanoBanana2AIO:
             "response_modalities": ["TEXT", "IMAGE"],
             "image_config": types.ImageConfig(**image_config_kwargs),
             "temperature": temperature,
+            "seed": seed,
             "thinking_config": types.ThinkingConfig(
                 thinking_level=thinking_level,
                 include_thoughts=include_thoughts,
@@ -151,7 +153,7 @@ class NanoBanana2AIO:
         return torch.zeros(1, 64, 64, 3)
 
     def generate_unified(self, model_name, prompt, image_count=1, use_search=True, use_image_search=False, 
-                         thinking_level="minimal", include_thoughts=False,
+                         thinking_level="minimal", include_thoughts=False, seed=0,
                          image_1=None, image_2=None, image_3=None, image_4=None, image_5=None, 
                          image_6=None, image_7=None, image_8=None, image_9=None, image_10=None,
                          image_11=None, image_12=None, image_13=None, image_14=None, 
@@ -168,6 +170,9 @@ class NanoBanana2AIO:
             valid_thinking_levels = ["minimal", "high"]
             if thinking_level not in valid_thinking_levels:
                 return self._handle_error(f"Invalid thinking level. Valid options: {', '.join(valid_thinking_levels)}")
+
+            if seed < 0 or seed > 2147483647:
+                return self._handle_error("Seed must be between 0 and 2147483647")
 
             if image_count < 1 or image_count > 10:
                 return self._handle_error("Image count must be between 1 and 10")
@@ -197,12 +202,12 @@ class NanoBanana2AIO:
             if image_count == 1:
                 return self._generate_single_image(
                     model_name, prompt, use_search, use_image_search, approach, contents,
-                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts
+                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts, seed
                 )
             else:
                 return self._generate_multiple_images(
                     model_name, prompt, image_count, use_search, use_image_search, approach, contents,
-                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts
+                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts, seed
                 )
 
         except ValueError as e:
@@ -212,7 +217,7 @@ class NanoBanana2AIO:
         except Exception as e:
             return self._handle_error(f"{type(e).__name__} in NanoBanana2AIO: {e}")
 
-    def _generate_single_image(self, model_name, prompt, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts):
+    def _generate_single_image(self, model_name, prompt, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts, seed):
         """Generate a single image with grounding capabilities."""
         if approach == "VERTEXAI":
             if not PROJECT_ID or not LOCATION:
@@ -226,7 +231,7 @@ class NanoBanana2AIO:
 
             client = genai.Client(api_key=GOOGLE_API_KEY)
 
-        config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
+        config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts, seed)
 
         response = client.models.generate_content(
             model=model_name,
@@ -268,7 +273,7 @@ class NanoBanana2AIO:
 
         return (image_tensor, thinking, grounding_sources, thought_images)
 
-    def _generate_multiple_images(self, model_name, prompt, image_count, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts):
+    def _generate_multiple_images(self, model_name, prompt, image_count, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts, seed):
         """Generate multiple images with grounding capabilities."""
         generated_images = []
         all_thinking_responses = []
@@ -291,7 +296,7 @@ class NanoBanana2AIO:
 
                 client = genai.Client(api_key=GOOGLE_API_KEY)
 
-            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
+            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts, seed)
 
             response = client.models.generate_content(
                 model=model_name,

--- a/nodes/nano_banana_2_aio.py
+++ b/nodes/nano_banana_2_aio.py
@@ -9,7 +9,7 @@ from ..utils.image_utils import tensor_to_pil
 
 class NanoBanana2AIO:
     """
-    Nano Banana 2 AIO node using gemini-3.1-flash-image-preview model.
+    Nano Banana 2 AIO node using gemini-3.1-flash-image model.
     Optimized for speed and high-volume use cases with support for:
     - Up to 14 reference images (10 objects + 4 characters)
     - New aspect ratios: 1:4, 4:1, 1:8, 8:1
@@ -22,7 +22,7 @@ class NanoBanana2AIO:
 
     @classmethod
     def INPUT_TYPES(s):
-        model_list = ["gemini-3.1-flash-image-preview"]
+        model_list = ["gemini-3.1-flash-image", "gemini-3.1-flash-image-preview"]
         return {
             "required": {
                 "model_name": (model_list, {"default": model_list[0]}),
@@ -30,6 +30,8 @@ class NanoBanana2AIO:
                 "image_count": ("INT", {"default": 1, "min": 1, "max": 10, "step": 1}),
                 "use_search": ("BOOLEAN", {"default": False}),
                 "use_image_search": ("BOOLEAN", {"default": False}),
+                "thinking_level": (["minimal", "high"], {"default": "minimal"}),
+                "include_thoughts": ("BOOLEAN", {"default": False}),
             },
             "optional": {
                 "image_1": ("IMAGE",), "image_2": ("IMAGE",), "image_3": ("IMAGE",),
@@ -43,13 +45,13 @@ class NanoBanana2AIO:
             }
         }
 
-    RETURN_TYPES = ("IMAGE", "STRING", "STRING")
-    RETURN_NAMES = ("images", "thinking", "grounding_sources")
+    RETURN_TYPES = ("IMAGE", "STRING", "STRING", "IMAGE")
+    RETURN_NAMES = ("images", "thinking", "grounding_sources", "thought_images")
 
     FUNCTION = "generate_unified"
     CATEGORY = "Ru4ls/NanoBanana"
 
-    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name):
+    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts):
         """Centralized config creation with proper AFC handling and Image Search support."""
         if "preview" in model_name and not self._preview_warning_shown:
             print(f"Warning: Using preview model {model_name} which may have unstable tool support")
@@ -66,6 +68,10 @@ class NanoBanana2AIO:
             "response_modalities": ["TEXT", "IMAGE"],
             "image_config": types.ImageConfig(**image_config_kwargs),
             "temperature": temperature,
+            "thinking_config": types.ThinkingConfig(
+                thinking_level=thinking_level,
+                include_thoughts=include_thoughts,
+            ),
             "automatic_function_calling": types.AutomaticFunctionCallingConfig(disable=True)
         }
 
@@ -100,9 +106,52 @@ class NanoBanana2AIO:
 
     def _handle_error(self, message):
         print(f"\033[91mERROR: {message}\033[0m")
-        return (torch.zeros(1, 64, 64, 3), "", "")
+        return (torch.zeros(1, 64, 64, 3), "", "", torch.zeros(1, 64, 64, 3))
+
+    def _response_parts(self, response):
+        """Separate final response parts from thought parts."""
+        final_image_bytes = None
+        response_text_parts = []
+        thought_text_parts = []
+        thought_image_bytes = []
+
+        for part in response.candidates[0].content.parts:
+            is_thought = bool(getattr(part, "thought", False))
+            inline_data = getattr(part, "inline_data", None)
+            text = getattr(part, "text", None)
+
+            if inline_data:
+                if is_thought:
+                    thought_image_bytes.append(inline_data.data)
+                elif final_image_bytes is None:
+                    final_image_bytes = inline_data.data
+
+            if text:
+                if is_thought:
+                    thought_text_parts.append(text)
+                else:
+                    response_text_parts.append(text)
+
+        return {
+            "final_image_bytes": final_image_bytes,
+            "response_text": "".join(response_text_parts),
+            "thought_text": "".join(thought_text_parts),
+            "thought_image_bytes": thought_image_bytes,
+        }
+
+    def _image_bytes_to_tensor(self, image_bytes):
+        pil_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        image_np = np.array(pil_image).astype(np.float32) / 255.0
+        return torch.from_numpy(image_np)[None,]
+
+    def _image_bytes_list_to_tensor(self, image_bytes_list):
+        tensors = [self._image_bytes_to_tensor(image_bytes) for image_bytes in image_bytes_list]
+        if tensors:
+            return torch.cat(tensors, dim=0)
+        return torch.zeros(1, 64, 64, 3)
 
     def generate_unified(self, model_name, prompt, image_count=1, use_search=True, use_image_search=False, 
+                         thinking_level="minimal", include_thoughts=False,
                          image_1=None, image_2=None, image_3=None, image_4=None, image_5=None, 
                          image_6=None, image_7=None, image_8=None, image_9=None, image_10=None,
                          image_11=None, image_12=None, image_13=None, image_14=None, 
@@ -115,6 +164,10 @@ class NanoBanana2AIO:
 
             if not model_name:
                 return self._handle_error("Model name is required")
+
+            valid_thinking_levels = ["minimal", "high"]
+            if thinking_level not in valid_thinking_levels:
+                return self._handle_error(f"Invalid thinking level. Valid options: {', '.join(valid_thinking_levels)}")
 
             if image_count < 1 or image_count > 10:
                 return self._handle_error("Image count must be between 1 and 10")
@@ -144,12 +197,12 @@ class NanoBanana2AIO:
             if image_count == 1:
                 return self._generate_single_image(
                     model_name, prompt, use_search, use_image_search, approach, contents,
-                    aspect_ratio, image_size, temperature
+                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts
                 )
             else:
                 return self._generate_multiple_images(
                     model_name, prompt, image_count, use_search, use_image_search, approach, contents,
-                    aspect_ratio, image_size, temperature
+                    aspect_ratio, image_size, temperature, thinking_level, include_thoughts
                 )
 
         except ValueError as e:
@@ -159,7 +212,7 @@ class NanoBanana2AIO:
         except Exception as e:
             return self._handle_error(f"{type(e).__name__} in NanoBanana2AIO: {e}")
 
-    def _generate_single_image(self, model_name, prompt, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature):
+    def _generate_single_image(self, model_name, prompt, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts):
         """Generate a single image with grounding capabilities."""
         if approach == "VERTEXAI":
             if not PROJECT_ID or not LOCATION:
@@ -173,7 +226,7 @@ class NanoBanana2AIO:
 
             client = genai.Client(api_key=GOOGLE_API_KEY)
 
-        config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name)
+        config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
 
         response = client.models.generate_content(
             model=model_name,
@@ -193,14 +246,11 @@ class NanoBanana2AIO:
                     print(f"Debug: Parts - {response.candidates[0].content.parts}")
             return self._handle_error(f"Generation failed with reason: {reason}")
 
-        image_bytes = None
-        text_response = ""
-
-        for part in response.candidates[0].content.parts:
-            if part.inline_data and image_bytes is None:
-                image_bytes = part.inline_data.data
-            elif part.text:
-                text_response += part.text
+        parts = self._response_parts(response)
+        image_bytes = parts["final_image_bytes"]
+        text_response = parts["response_text"]
+        thinking = parts["thought_text"]
+        thought_images = self._image_bytes_list_to_tensor(parts["thought_image_bytes"])
 
         grounding_sources = self.extract_grounding_data(response)
 
@@ -209,26 +259,21 @@ class NanoBanana2AIO:
             print(f"Debug: Full response - {response}")
             print(f"Debug: Response parts - {response.candidates[0].content.parts}")
             print(f"Debug: Text response - {text_response[:500] if text_response else 'None'}")
+            print(f"Debug: Thinking response - {thinking[:500] if thinking else 'None'}")
             if grounding_sources:
                 print(f"Debug: Grounding sources - {grounding_sources[:500] if grounding_sources else 'None'}")
             return self._handle_error("No image data found in the API response.")
 
-        pil_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        image_tensor = self._image_bytes_to_tensor(image_bytes)
 
-        image_np = np.array(pil_image).astype(np.float32) / 255.0
-        image_tensor = torch.from_numpy(image_np)[None,]
+        return (image_tensor, thinking, grounding_sources, thought_images)
 
-        if approach == "API":
-            text_response = "To access the full text response, please use Vertex AI approach with PROJECT_ID and LOCATION set up."
-            grounding_sources = f"{grounding_sources}\n\nFor full grounding capabilities, please use Vertex AI approach with PROJECT_ID and LOCATION configured."
-
-        return (image_tensor, text_response, grounding_sources)
-
-    def _generate_multiple_images(self, model_name, prompt, image_count, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature):
+    def _generate_multiple_images(self, model_name, prompt, image_count, use_search, use_image_search, approach, contents, aspect_ratio, image_size, temperature, thinking_level, include_thoughts):
         """Generate multiple images with grounding capabilities."""
         generated_images = []
-        all_text_responses = []
+        all_thinking_responses = []
         all_grounding_sources = []
+        all_thought_image_bytes = []
 
         for i in range(image_count):
             current_prompt = f"{prompt} (Image {i+1} of {image_count})"
@@ -246,7 +291,7 @@ class NanoBanana2AIO:
 
                 client = genai.Client(api_key=GOOGLE_API_KEY)
 
-            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name)
+            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
 
             response = client.models.generate_content(
                 model=model_name,
@@ -266,14 +311,11 @@ class NanoBanana2AIO:
                         print(f"Debug: Parts - {response.candidates[0].content.parts}")
                 return self._handle_error(f"Generation failed with reason: {reason}")
 
-            image_bytes = None
-            text_response = ""
-
-            for part in response.candidates[0].content.parts:
-                if part.inline_data and image_bytes is None:
-                    image_bytes = part.inline_data.data
-                elif part.text:
-                    text_response += part.text
+            parts = self._response_parts(response)
+            image_bytes = parts["final_image_bytes"]
+            text_response = parts["response_text"]
+            thinking = parts["thought_text"]
+            all_thought_image_bytes.extend(parts["thought_image_bytes"])
 
             grounding_sources = self.extract_grounding_data(response)
 
@@ -281,15 +323,13 @@ class NanoBanana2AIO:
                 # Debug: print response parts to help diagnose the issue
                 print(f"Debug: Response parts - {response.candidates[0].content.parts}")
                 print(f"Debug: Text response - {text_response[:500] if text_response else 'None'}")
+                print(f"Debug: Thinking response - {thinking[:500] if thinking else 'None'}")
                 return self._handle_error("No image data found in the API response.")
 
-            pil_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
-
-            image_np = np.array(pil_image).astype(np.float32) / 255.0
-            image_tensor = torch.from_numpy(image_np)[None,]
+            image_tensor = self._image_bytes_to_tensor(image_bytes)
 
             generated_images.append(image_tensor)
-            all_text_responses.append(text_response)
+            all_thinking_responses.append(thinking)
             all_grounding_sources.append(grounding_sources)
 
         if len(generated_images) > 0:
@@ -297,14 +337,11 @@ class NanoBanana2AIO:
         else:
             return self._handle_error("No images were generated.")
 
-        combined_text_responses = "\n\n".join(all_text_responses)
+        combined_thinking_responses = "\n\n".join(all_thinking_responses)
         combined_grounding_sources = "\n\n".join(all_grounding_sources)
+        thought_images = self._image_bytes_list_to_tensor(all_thought_image_bytes)
 
-        if approach == "API":
-            combined_text_responses = "To access the full text responses, please use Vertex AI approach with PROJECT_ID and LOCATION set up."
-            combined_grounding_sources = f"{combined_grounding_sources}\n\nFor full grounding capabilities, please use Vertex AI approach with PROJECT_ID and LOCATION configured."
-
-        return (combined_images, combined_text_responses, combined_grounding_sources)
+        return (combined_images, combined_thinking_responses, combined_grounding_sources, thought_images)
 
     def extract_grounding_data(self, response):
         """Extracts grounding sources from the response."""
@@ -315,7 +352,7 @@ class NanoBanana2AIO:
 
             text_content = ""
             for part in candidate.content.parts:
-                if hasattr(part, 'text') and part.text:
+                if hasattr(part, 'text') and part.text and not bool(getattr(part, "thought", False)):
                     text_content += part.text
 
             if text_content:
@@ -374,6 +411,6 @@ class NanoBanana2AIO:
             candidate = response.candidates[0]
             text_content = ""
             for part in candidate.content.parts:
-                if hasattr(part, 'text') and part.text:
+                if hasattr(part, 'text') and part.text and not bool(getattr(part, "thought", False)):
                     text_content += part.text
             return text_content + f"\n\nGrounding information not available: {str(e)}"

--- a/nodes/nano_banana_2_multiturn_chat.py
+++ b/nodes/nano_banana_2_multiturn_chat.py
@@ -9,7 +9,7 @@ from ..utils.image_utils import tensor_to_pil
 
 class NanoBanana2MultiTurnChat:
     """
-    Nano Banana 2 Multi-Turn Chat node using gemini-3.1-flash-image-preview model.
+    Nano Banana 2 Multi-Turn Chat node using gemini-3.1-flash-image model.
     Supports conversational image generation and editing with preserved context.
     Features:
     - Up to 14 reference images (10 objects + 4 characters)
@@ -31,7 +31,7 @@ class NanoBanana2MultiTurnChat:
 
     @classmethod
     def INPUT_TYPES(s):
-        model_list = ["gemini-3.1-flash-image-preview"]
+        model_list = ["gemini-3.1-flash-image", "gemini-3.1-flash-image-preview"]
         return {
             "required": {
                 "model_name": (model_list, {"default": model_list[0]}),
@@ -39,6 +39,8 @@ class NanoBanana2MultiTurnChat:
                 "reset_chat": ("BOOLEAN", {"default": False}),
                 "use_search": ("BOOLEAN", {"default": False}),
                 "use_image_search": ("BOOLEAN", {"default": False}),
+                "thinking_level": (["minimal", "high"], {"default": "minimal"}),
+                "include_thoughts": ("BOOLEAN", {"default": False}),
                 "aspect_ratio": (["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9", "Auto"], {"default": "1:1"}),
                 "image_size": (["512px", "1K", "2K", "4K"], {"default": "2K"}),
                 "temperature": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.1}),
@@ -52,17 +54,17 @@ class NanoBanana2MultiTurnChat:
             }
         }
 
-    RETURN_TYPES = ("IMAGE", "STRING", "STRING", "STRING")
-    RETURN_NAMES = ("image", "response_text", "metadata", "chat_history")
+    RETURN_TYPES = ("IMAGE", "STRING", "STRING", "STRING", "STRING", "IMAGE")
+    RETURN_NAMES = ("image", "response_text", "metadata", "chat_history", "thinking", "thought_images")
 
     FUNCTION = "generate_multiturn_image"
     CATEGORY = "Ru4ls/NanoBanana"
 
     def _handle_error(self, message):
         print(f"\033[91mERROR: {message}\033[0m")
-        return (torch.zeros(1, 64, 64, 3), "", "", [])
+        return (torch.zeros(1, 64, 64, 3), "", "", "", "", torch.zeros(1, 64, 64, 3))
 
-    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name):
+    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts):
         """Centralized config creation with proper AFC handling and Image Search support."""
         if "preview" in model_name and not self._preview_warning_shown:
             print(f"Warning: Using preview model {model_name} which may have unstable tool support")
@@ -79,6 +81,10 @@ class NanoBanana2MultiTurnChat:
             "response_modalities": ["TEXT", "IMAGE"],
             "image_config": types.ImageConfig(**image_config_kwargs),
             "temperature": temperature,
+            "thinking_config": types.ThinkingConfig(
+                thinking_level=thinking_level,
+                include_thoughts=include_thoughts,
+            ),
             "automatic_function_calling": types.AutomaticFunctionCallingConfig(disable=True)
         }
 
@@ -107,6 +113,48 @@ class NanoBanana2MultiTurnChat:
         config = types.GenerateContentConfig(**config_kwargs)
         return config
 
+    def _response_parts(self, response):
+        """Separate final response parts from thought parts."""
+        final_image_bytes = None
+        response_text_parts = []
+        thought_text_parts = []
+        thought_image_bytes = []
+
+        for part in response.candidates[0].content.parts:
+            is_thought = bool(getattr(part, "thought", False))
+            inline_data = getattr(part, "inline_data", None)
+            text = getattr(part, "text", None)
+
+            if inline_data:
+                if is_thought:
+                    thought_image_bytes.append(inline_data.data)
+                elif final_image_bytes is None:
+                    final_image_bytes = inline_data.data
+
+            if text:
+                if is_thought:
+                    thought_text_parts.append(text)
+                else:
+                    response_text_parts.append(text)
+
+        return {
+            "final_image_bytes": final_image_bytes,
+            "response_text": "".join(response_text_parts),
+            "thought_text": "".join(thought_text_parts),
+            "thought_image_bytes": thought_image_bytes,
+        }
+
+    def _image_bytes_to_tensor(self, image_bytes):
+        pil_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        image_np = np.array(pil_image).astype(np.float32) / 255.0
+        return torch.from_numpy(image_np)[None,]
+
+    def _image_bytes_list_to_tensor(self, image_bytes_list):
+        tensors = [self._image_bytes_to_tensor(image_bytes) for image_bytes in image_bytes_list]
+        if tensors:
+            return torch.cat(tensors, dim=0)
+        return torch.zeros(1, 64, 64, 3)
+
     def _create_client(self, approach, model_name):
         """Create a new client based on the approach."""
         if approach == "VERTEXAI":
@@ -124,6 +172,7 @@ class NanoBanana2MultiTurnChat:
         return client
 
     def generate_multiturn_image(self, model_name, prompt, reset_chat=False, use_search=False, use_image_search=False,
+                                  thinking_level="minimal", include_thoughts=False,
                                   aspect_ratio="1:1", image_size="2K", temperature=1.0,
                                   image_1=None, image_2=None, image_3=None, image_4=None, image_5=None,
                                   image_6=None, image_7=None, image_8=None, image_9=None, image_10=None,
@@ -136,6 +185,10 @@ class NanoBanana2MultiTurnChat:
 
             if not model_name:
                 return self._handle_error("Model name is required")
+
+            valid_thinking_levels = ["minimal", "high"]
+            if thinking_level not in valid_thinking_levels:
+                return self._handle_error(f"Invalid thinking level. Valid options: {', '.join(valid_thinking_levels)}")
 
             # Validate aspect ratio
             valid_ratios = ["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9", "Auto"]
@@ -182,7 +235,7 @@ class NanoBanana2MultiTurnChat:
                 contents.insert(0, prev_image)
 
             # Create config
-            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name)
+            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
 
             # Create the chat session
             chat = client.chats.create(
@@ -206,19 +259,17 @@ class NanoBanana2MultiTurnChat:
                 return self._handle_error(f"Generation failed with reason: {reason}")
 
             # Parse the response
-            image_bytes = None
-            text_response = ""
-
-            for part in response.candidates[0].content.parts:
-                if hasattr(part, 'inline_data') and part.inline_data and image_bytes is None:
-                    image_bytes = part.inline_data.data
-                elif hasattr(part, 'text') and part.text:
-                    text_response += part.text
+            parts = self._response_parts(response)
+            image_bytes = parts["final_image_bytes"]
+            text_response = parts["response_text"]
+            thinking = parts["thought_text"]
+            thought_images = self._image_bytes_list_to_tensor(parts["thought_image_bytes"])
 
             if image_bytes is None:
                 print(f"Debug: Full response - {response}")
                 print(f"Debug: Response parts - {response.candidates[0].content.parts}")
                 print(f"Debug: Text response - {text_response[:500] if text_response else 'None'}")
+                print(f"Debug: Thinking response - {thinking[:500] if thinking else 'None'}")
                 return self._handle_error("No image data found in the API response.")
 
             # Update the stored image data for next turn
@@ -231,9 +282,7 @@ class NanoBanana2MultiTurnChat:
             })
 
             # Convert image to tensor
-            pil_image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
-            image_np = np.array(pil_image).astype(np.float32) / 255.0
-            image_tensor = torch.from_numpy(image_np)[None,]
+            image_tensor = self._image_bytes_to_tensor(image_bytes)
 
             # Extract metadata
             metadata = self._extract_metadata(response)
@@ -241,7 +290,7 @@ class NanoBanana2MultiTurnChat:
             # Convert conversation history to a string representation
             chat_history_str = str(self.conversation_history)
 
-            return (image_tensor, text_response, metadata, chat_history_str)
+            return (image_tensor, text_response, metadata, chat_history_str, thinking, thought_images)
 
         except ValueError as e:
             return self._handle_error(f"ValueError in NanoBanana2MultiTurnChat: {e}")

--- a/nodes/nano_banana_2_multiturn_chat.py
+++ b/nodes/nano_banana_2_multiturn_chat.py
@@ -41,6 +41,7 @@ class NanoBanana2MultiTurnChat:
                 "use_image_search": ("BOOLEAN", {"default": False}),
                 "thinking_level": (["minimal", "high"], {"default": "minimal"}),
                 "include_thoughts": ("BOOLEAN", {"default": False}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "control_after_generate": True}),
                 "aspect_ratio": (["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9", "Auto"], {"default": "1:1"}),
                 "image_size": (["512px", "1K", "2K", "4K"], {"default": "2K"}),
                 "temperature": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.1}),
@@ -64,7 +65,7 @@ class NanoBanana2MultiTurnChat:
         print(f"\033[91mERROR: {message}\033[0m")
         return (torch.zeros(1, 64, 64, 3), "", "", "", "", torch.zeros(1, 64, 64, 3))
 
-    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts):
+    def _create_config(self, aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts, seed):
         """Centralized config creation with proper AFC handling and Image Search support."""
         if "preview" in model_name and not self._preview_warning_shown:
             print(f"Warning: Using preview model {model_name} which may have unstable tool support")
@@ -81,6 +82,7 @@ class NanoBanana2MultiTurnChat:
             "response_modalities": ["TEXT", "IMAGE"],
             "image_config": types.ImageConfig(**image_config_kwargs),
             "temperature": temperature,
+            "seed": seed,
             "thinking_config": types.ThinkingConfig(
                 thinking_level=thinking_level,
                 include_thoughts=include_thoughts,
@@ -172,7 +174,7 @@ class NanoBanana2MultiTurnChat:
         return client
 
     def generate_multiturn_image(self, model_name, prompt, reset_chat=False, use_search=False, use_image_search=False,
-                                  thinking_level="minimal", include_thoughts=False,
+                                  thinking_level="minimal", include_thoughts=False, seed=0,
                                   aspect_ratio="1:1", image_size="2K", temperature=1.0,
                                   image_1=None, image_2=None, image_3=None, image_4=None, image_5=None,
                                   image_6=None, image_7=None, image_8=None, image_9=None, image_10=None,
@@ -189,6 +191,9 @@ class NanoBanana2MultiTurnChat:
             valid_thinking_levels = ["minimal", "high"]
             if thinking_level not in valid_thinking_levels:
                 return self._handle_error(f"Invalid thinking level. Valid options: {', '.join(valid_thinking_levels)}")
+
+            if seed < 0 or seed > 2147483647:
+                return self._handle_error("Seed must be between 0 and 2147483647")
 
             # Validate aspect ratio
             valid_ratios = ["1:1", "1:4", "1:8", "2:3", "3:2", "3:4", "4:1", "4:3", "4:5", "5:4", "8:1", "9:16", "16:9", "21:9", "Auto"]
@@ -235,7 +240,7 @@ class NanoBanana2MultiTurnChat:
                 contents.insert(0, prev_image)
 
             # Create config
-            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts)
+            config = self._create_config(aspect_ratio, image_size, temperature, use_search, use_image_search, model_name, thinking_level, include_thoughts, seed)
 
             # Create the chat session
             chat = client.chats.create(


### PR DESCRIPTION
## Summary

Adds configurable Gemini thinking support to the Nano Banana 2 AIO and Multi-Turn Chat nodes.

## Changes

- Added `thinking_level` input with `minimal` and `high` options
- Added `include_thoughts` boolean input
- Sends `types.ThinkingConfig` in Nano Banana 2 requests
- Separates final response parts from thought text/images
- Adds optional `thought_images` output
- Updates default Nano Banana 2 model to `gemini-3.1-flash-image`
- Keeps `gemini-3.1-flash-image-preview` selectable for compatibility
- Removes the obsolete API-vs-Vertex text override in the Nano Banana 2 AIO node
- Updates README and changelog documentation

## Validation

- Ran `uv run python -m py_compile nodes\nano_banana_2_aio.py nodes\nano_banana_2_multiturn_chat.py`
- Ran `git diff --check`
- Tested modified nodes (using Google Generative AI API) in ComfyUI